### PR TITLE
Fix to cache-purge command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,5 +52,5 @@ rsync -e "ssh -v -p 22 -i ${ONE_SSH_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=n
 
 
 # Clear cache
-ssh -v -p 22 -i ${ONE_SSH_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no $ONE_SSH_USER "cache-purge"
+ssh -v -p 22 -i ${ONE_SSH_KEY_PRIVATE_PATH} -o StrictHostKeyChecking=no $ONE_SSH_USER "cache-purge -v www.${ONE_DOMAIN_NAME}"
 echo "SUCCESS: Site has been deployed and cache has been flushed."


### PR DESCRIPTION
Fixed error when `cache-purge` was called over `ssh` without a url.

<img src="https://github.com/RostiMelk/one.com-deployer/assets/21254995/b797e3ac-9fe7-4d97-b13e-73be323165b0" width=400/>
